### PR TITLE
Update Stable SOPS Version

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -11,7 +11,7 @@ import * as toolCache from '@actions/tool-cache';
 import * as core from '@actions/core';
 
 const sopsToolName = 'sops';
-const stableSopsVersion = 'v3.7.2';
+const stableSopsVersion = 'v3.7.3';
 const sopsAllReleasesUrl = 'https://api.github.com/repos/mozilla/sops/releases';
 
 function getExecutableExtension(): string {


### PR DESCRIPTION
## Environment variables to add/change


## What does this pull request do?
- Changes the latest stable SOPS version from `v3.7.2` to `v3.7.3`

## How should this pull request be tested?


## Questions or comments:
Ideally, the `getstableSopsVersion` function should be getting this value using `toolCache.downloadTool`, however that seems to be throwing a `403`. Not entirely sure what the recommended solution is for that - [there is an open issue for it](https://github.com/actions/toolkit/issues/986) - so in the meantime this will update the fallback to the latest SOPS version.
