### PR TITLE
Bump latest stable version to 3.7.3

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -11,7 +11,7 @@ import * as toolCache from '@actions/tool-cache';
 import * as core from '@actions/core';
 
 const sopsToolName = 'sops';
-const stableSopsVersion = 'v3.7.2';
+const stableSopsVersion = 'v3.7.3';
 const sopsAllReleasesUrl = 'https://api.github.com/repos/mozilla/sops/releases';
 
 function getExecutableExtension(): string {


### PR DESCRIPTION
## Environment variables to add/change
n/a

## What does this pull request do?
This resolves a bug where workload identity federation does not work with sops in 3.7.2. This happens intermittently when this action fails to get the latest version due to https://github.com/mdgreenwald/mozilla-sops-action/issues/152

## How should this pull request be tested?
Purposely omit the http call to get the latest version, and confirm that 3.7.3 is used.

## Questions or comments:

