### PR TITLE
Updates checkout action on release workflow to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
## What does this pull request do?
It updates the checkout action on release workflow to v3 to use the node 16 version

