### PR TITLE
Add optional GitHub token input to avoid API rate limits

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,6 +74,7 @@ jobs:
            uses: ./
            with:
               version: latest
+              token: ${{ secrets.GITHUB_TOKEN }}
 
          - name: Validate latest SOPS
            shell: bash

--- a/README.md
+++ b/README.md
@@ -12,17 +12,28 @@ Repurposed from [Azure/setup-helm](https://github.com/Azure/setup-helm).
 - name: Install SOPS
   uses: mdgreenwald/mozilla-sops-action@v2.0.1
   with:
-     version: 'v3.13.0' # default is latest stable
+     version: 'v3.13.1' # default is latest stable
   id: install
 ```
 
 Acceptable values for `version`:
 
 - `latest` (default) — queries the GitHub releases API for the current latest release
-- a full semver tag like `v3.13.0`
-- a bare semver like `3.13.0` — automatically normalized to `v3.13.0`
+- a full semver tag like `v3.13.1`
+- a bare semver like `3.13.1` — automatically normalized to `v3.13.1`
 
 The cached `sops` binary is prepended to `PATH` and its absolute path is exported as the `sops-path` output.
+
+### Avoiding GitHub API rate limits
+
+Resolving `version: latest` queries the GitHub API, which is capped at 60 requests/hour per source IP when unauthenticated — easy to exhaust on shared GitHub-hosted runner IP pools. Pass the job's `GITHUB_TOKEN` to raise that to 1000/hour:
+
+```yaml
+- name: Install SOPS
+  uses: mdgreenwald/mozilla-sops-action@v2.0.1
+  with:
+     token: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ### Supported platforms
 
@@ -44,10 +55,11 @@ This action publishes immutable tags only (`v2.0.0`, `v2.0.1`, …). There is no
 
 ## Inputs
 
-| Input             | Required | Default                                              | Description                                                                                                                         |
-| ----------------- | -------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `version`         | yes      | `latest`                                             | SOPS version to install. Accepts `latest`, `vX.Y.Z`, or `X.Y.Z`.                                                                    |
-| `downloadBaseURL` | no       | `https://github.com/getsops/sops/releases/download/` | Base URL for the SOPS binary. Must end with a trailing slash and follow the `<tag>/<asset>` layout used by `getsops/sops` releases. |
+| Input             | Required | Default                                              | Description                                                                                                                                                                                             |
+| ----------------- | -------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`         | yes      | `latest`                                             | SOPS version to install. Accepts `latest`, `vX.Y.Z`, or `X.Y.Z`.                                                                                                                                        |
+| `downloadBaseURL` | no       | `https://github.com/getsops/sops/releases/download/` | Base URL for the SOPS binary. Must end with a trailing slash and follow the `<tag>/<asset>` layout used by `getsops/sops` releases.                                                                     |
+| `token`           | no       | `''`                                                 | GitHub token used to authenticate the `latest`-version lookup, raising the GitHub API rate limit from 60/hr to 1000/hr. Typically `${{ secrets.GITHUB_TOKEN }}`. Unused when `version` is not `latest`. |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Mozilla SOPS Installer'
-description: 'Install a specific version of the sops binary. Acceptable values are latest or any semantic version string like v3.13.0'
+description: 'Install a specific version of the sops binary. Acceptable values are latest or any semantic version string like v3.13.1'
 inputs:
    version:
       description: 'Version of sops'
@@ -9,6 +9,10 @@ inputs:
       description: 'Set the download base URL (must end with a trailing slash and follow the <tag>/<asset> layout used by getsops/sops releases)'
       required: false
       default: 'https://github.com/getsops/sops/releases/download/'
+   token:
+      description: 'GitHub token used to authenticate the request that resolves the "latest" SOPS version, raising the GitHub API rate limit from 60/hr (unauthenticated) to 1000/hr. Typically `${{ secrets.GITHUB_TOKEN }}`. Unused when `version` is not `latest`.'
+      required: false
+      default: ''
 outputs:
    sops-path:
       description: 'Path to the cached sops binary'

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
       required: false
       default: 'https://github.com/getsops/sops/releases/download/'
    token:
-      description: 'GitHub token used to authenticate the request that resolves the "latest" SOPS version, raising the GitHub API rate limit from 60/hr (unauthenticated) to 1000/hr. Typically `${{ secrets.GITHUB_TOKEN }}`. Unused when `version` is not `latest`.'
+      description: 'GitHub token used to authenticate the request that resolves the "latest" SOPS version, raising the GitHub API rate limit from 60/hr (unauthenticated) to 1000/hr. Typically the workflow GITHUB_TOKEN secret. Unused when `version` is not `latest`.'
       required: false
       default: ''
 outputs:

--- a/lib/index.js
+++ b/lib/index.js
@@ -34694,7 +34694,7 @@ function _unique(values) {
 
 
 const sopsToolName = 'sops';
-const stableSopsVersion = 'v3.13.0';
+const stableSopsVersion = 'v3.13.1';
 const sopsLatestReleaseURL = 'https://api.github.com/repos/getsops/sops/releases/latest';
 async function run() {
     let version = getInput('version', { required: true });
@@ -34703,7 +34703,8 @@ async function run() {
     }
     if (version.toLocaleLowerCase() === 'latest') {
         info('Getting latest SOPS version');
-        version = await getLatestSopsVersion();
+        const token = getInput('token', { required: false });
+        version = await getLatestSopsVersion(token);
     }
     const downloadBaseURL = getInput('downloadBaseURL', { required: false });
     startGroup(`Installing ${version}`);
@@ -34725,12 +34726,17 @@ function getValidVersion(version) {
     return 'v' + version;
 }
 // Gets the latest SOPS version or returns the stable fallback if the API is
-// unreachable.
-async function getLatestSopsVersion() {
+// unreachable. Passing a GitHub token raises the API rate limit from 60/hr
+// (unauthenticated) to 1000/hr.
+async function getLatestSopsVersion(token) {
     try {
-        const response = await fetch(sopsLatestReleaseURL, {
-            headers: { Accept: 'application/vnd.github+json' }
-        });
+        const headers = {
+            Accept: 'application/vnd.github+json'
+        };
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+        const response = await fetch(sopsLatestReleaseURL, { headers });
         if (!response.ok) {
             throw new Error(`HTTP ${response.status}`);
         }

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -133,6 +133,38 @@ describe('run.ts', () => {
       expect(await run.getLatestSopsVersion()).toBe('v9.99.999')
    })
 
+   test('getLatestSopsVersion() - omits Authorization header when no token is given', async () => {
+      const res = {
+         ok: true,
+         status: 200,
+         json: async () => ({tag_name: 'v9.99.999'})
+      } as unknown as Response
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(res)
+      global.fetch = mockFetch
+      await run.getLatestSopsVersion()
+      const headers = mockFetch.mock.calls[0][1]?.headers as Record<
+         string,
+         string
+      >
+      expect(headers.Authorization).toBeUndefined()
+   })
+
+   test('getLatestSopsVersion() - sends Authorization header when a token is given', async () => {
+      const res = {
+         ok: true,
+         status: 200,
+         json: async () => ({tag_name: 'v9.99.999'})
+      } as unknown as Response
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(res)
+      global.fetch = mockFetch
+      await run.getLatestSopsVersion('my-token')
+      const headers = mockFetch.mock.calls[0][1]?.headers as Record<
+         string,
+         string
+      >
+      expect(headers.Authorization).toBe('Bearer my-token')
+   })
+
    test('getLatestSopsVersion() - fall back to stable on a non-OK response', async () => {
       const res = {
          ok: false,

--- a/src/run.ts
+++ b/src/run.ts
@@ -6,7 +6,7 @@ import * as toolCache from '@actions/tool-cache'
 import * as core from '@actions/core'
 
 const sopsToolName = 'sops'
-export const stableSopsVersion = 'v3.13.0'
+export const stableSopsVersion = 'v3.13.1'
 const sopsLatestReleaseURL =
    'https://api.github.com/repos/getsops/sops/releases/latest'
 
@@ -18,7 +18,8 @@ export async function run() {
    }
    if (version.toLocaleLowerCase() === 'latest') {
       core.info('Getting latest SOPS version')
-      version = await getLatestSopsVersion()
+      const token = core.getInput('token', {required: false})
+      version = await getLatestSopsVersion(token)
    }
 
    const downloadBaseURL = core.getInput('downloadBaseURL', {required: false})
@@ -45,12 +46,17 @@ export function getValidVersion(version: string): string {
 }
 
 // Gets the latest SOPS version or returns the stable fallback if the API is
-// unreachable.
-export async function getLatestSopsVersion(): Promise<string> {
+// unreachable. Passing a GitHub token raises the API rate limit from 60/hr
+// (unauthenticated) to 1000/hr.
+export async function getLatestSopsVersion(token?: string): Promise<string> {
    try {
-      const response = await fetch(sopsLatestReleaseURL, {
-         headers: {Accept: 'application/vnd.github+json'}
-      })
+      const headers: Record<string, string> = {
+         Accept: 'application/vnd.github+json'
+      }
+      if (token) {
+         headers.Authorization = `Bearer ${token}`
+      }
+      const response = await fetch(sopsLatestReleaseURL, {headers})
       if (!response.ok) {
          throw new Error(`HTTP ${response.status}`)
       }


### PR DESCRIPTION
## Summary

- Adds an optional `token` input. When set, the `latest`-version lookup against the GitHub API sends `Authorization: Bearer <token>`, raising the rate limit from 60/hr (unauthenticated, per source IP) to 1000/hr.
- Bumps the `stableSopsVersion` offline fallback to `v3.13.1` (current latest).
- Default behavior is unchanged when `token` is omitted (empty string, no header sent).

Fixes #152. Unauthenticated runner IP pools easily exhaust 60 req/hr, and the silent fallback to a hardcoded stable version on rate-limit failure was reported to cause sops to hang on an interactive prompt in CI (see issue comments).

## Test plan

- [x] `npm test` — 21/21 passing, including new tests asserting the `Authorization` header is sent/omitted correctly
- [x] `npm run format-check`
- [x] `npm run build` — `lib/index.js` rebuilt and committed
- [ ] Reviewer: confirm `token: ${{ secrets.GITHUB_TOKEN }}` works end-to-end in the integration workflow if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)