### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v2.1.0
+
+### Added
+
+- New optional `token` input. When set, the `latest`-version lookup against the GitHub API sends `Authorization: Bearer <token>`, raising the rate limit from 60/hr (unauthenticated, per source IP) to 1000/hr. Typically `${{ secrets.GITHUB_TOKEN }}`. ([#244](https://github.com/mdgreenwald/mozilla-sops-action/pull/244))
+
+### Security
+
+- Forced `js-yaml` to `^4.2.0` via `npm overrides` to fix a quadratic-complexity DoS in merge-key (`<<`) handling ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) / CVE-2026-53550). `js-yaml@3.x` was present only as a dev-only transitive dependency (via `ts-jest` → `@jest/transform` → `babel-plugin-istanbul` → `@istanbuljs/load-nyc-config`); the production bundle was never affected. ([#243](https://github.com/mdgreenwald/mozilla-sops-action/pull/243))
+
+### Internal
+
+- Bumped the `stableSopsVersion` offline fallback to `v3.13.1`.
+
 ## v2.0.1
 
 CI/tooling hardening release. No changes to `action.yml` or runtime behavior.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Repurposed from [Azure/setup-helm](https://github.com/Azure/setup-helm).
 
 ```yaml
 - name: Install SOPS
-  uses: mdgreenwald/mozilla-sops-action@v2.0.1
+  uses: mdgreenwald/mozilla-sops-action@v2.1.0
   with:
      version: 'v3.13.1' # default is latest stable
   id: install
@@ -30,7 +30,7 @@ Resolving `version: latest` queries the GitHub API, which is capped at 60 reques
 
 ```yaml
 - name: Install SOPS
-  uses: mdgreenwald/mozilla-sops-action@v2.0.1
+  uses: mdgreenwald/mozilla-sops-action@v2.1.0
   with:
      token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -50,7 +50,7 @@ Native binaries are installed for all of these runners:
 This action publishes immutable tags only (`v2.0.0`, `v2.0.1`, …). There is no floating `v2` tag. Pin to a full semver tag — or, for the strongest guarantee, pin to the commit SHA:
 
 ```yaml
-- uses: mdgreenwald/mozilla-sops-action@<commit-sha> # v2.0.1
+- uses: mdgreenwald/mozilla-sops-action@<commit-sha> # v2.1.0
 ```
 
 ## Inputs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "mozilla-sops-action",
-   "version": "2.0.1",
+   "version": "2.1.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "mozilla-sops-action",
-         "version": "2.0.1",
+         "version": "2.1.0",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "mozilla-sops-action",
-   "version": "2.0.1",
+   "version": "2.1.0",
    "private": true,
    "type": "module",
    "description": "GitHub Action to install a specific version of the SOPS binary",


### PR DESCRIPTION
Release prep for v2.1.0, bundling #243 and #244.

## Changes
- New optional `token` input for authenticated `latest`-version lookups (#244)
- Fixed js-yaml DoS via npm overrides (dev-only dependency, GHSA-h67p-54hq-rp68) (#243)
- Bumped `stableSopsVersion` offline fallback to `v3.13.1`

## Test plan
- [x] `npm ci`
- [x] `npm test` — 21/21 passing
- [x] `npm run build` — `lib/index.js` already up to date (no diff)
- [x] `npm run format-check`