### PR TITLE
fix: skip chmod when binary is already executable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34775,6 +34775,15 @@ function getSopsDownloadURL(baseURL, version) {
     const url = new URL(`${version}/${asset}`, normalizedBase);
     return url.toString();
 }
+function isExecutable(filePath) {
+    try {
+        external_node_fs_namespaceObject.accessSync(filePath, external_node_fs_namespaceObject.constants.X_OK);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
 async function downloadSops(baseURL, version) {
     let cachedToolpath = find(sopsToolName, version);
     if (cachedToolpath) {
@@ -34796,7 +34805,9 @@ async function downloadSops(baseURL, version) {
     if (!external_node_fs_namespaceObject.existsSync(sopspath)) {
         throw new Error(`SOPS executable not found in path ${cachedToolpath}`);
     }
-    external_node_fs_namespaceObject.chmodSync(sopspath, '777');
+    if (!isExecutable(sopspath)) {
+        external_node_fs_namespaceObject.chmodSync(sopspath, '777');
+    }
     return sopspath;
 }
 

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -18,6 +18,7 @@ jest.unstable_mockModule('node:os', () => ({
 
 jest.unstable_mockModule('node:fs', () => ({
    ...actualFs,
+   accessSync: jest.fn(),
    chmodSync: jest.fn(),
    existsSync: jest.fn(actualFs.existsSync),
    default: {...actualFs}
@@ -39,6 +40,9 @@ const mockArch = os.arch as jest.MockedFunction<typeof os.arch>
 const mockChmodSync = fs.chmodSync as jest.MockedFunction<typeof fs.chmodSync>
 const mockExistsSync = fs.existsSync as jest.MockedFunction<
    typeof fs.existsSync
+>
+const mockAccessSync = fs.accessSync as jest.MockedFunction<
+   typeof fs.accessSync
 >
 const mockFind = toolCache.find as jest.MockedFunction<typeof toolCache.find>
 const mockDownloadTool = toolCache.downloadTool as jest.MockedFunction<
@@ -196,6 +200,26 @@ describe('run.ts', () => {
       expect(run.getValidVersion('3.13.0')).toBe('v3.13.0')
    })
 
+   test('isExecutable() - return true when file is executable', () => {
+      mockAccessSync.mockImplementation(() => {})
+      expect(run.isExecutable('path/to/executable')).toBe(true)
+      expect(mockAccessSync).toHaveBeenCalledWith(
+         'path/to/executable',
+         fs.constants.X_OK
+      )
+   })
+
+   test('isExecutable() - return false when file is not executable', () => {
+      mockAccessSync.mockImplementation(() => {
+         throw new Error('Not executable')
+      })
+      expect(run.isExecutable('path/to/non-executable')).toBe(false)
+      expect(mockAccessSync).toHaveBeenCalledWith(
+         'path/to/non-executable',
+         fs.constants.X_OK
+      )
+   })
+
    test('downloadSops() - download SOPS and return path to it', async () => {
       mockFind.mockReturnValue('')
       mockDownloadTool.mockResolvedValue('pathToTool')
@@ -204,6 +228,7 @@ describe('run.ts', () => {
       mockArch.mockReturnValue('x64')
       mockChmodSync.mockImplementation(() => {})
       mockExistsSync.mockReturnValue(true)
+      mockAccessSync.mockImplementation(() => {})
 
       expect(await run.downloadSops(downloadBaseURL, 'v3.13.0')).toBe(
          path.join('pathToCachedDir', 'sops')
@@ -219,10 +244,7 @@ describe('run.ts', () => {
          'v3.13.0'
       )
       expect(mockChmodSync).toHaveBeenCalledWith('pathToTool', '777')
-      expect(mockChmodSync).toHaveBeenCalledWith(
-         path.join('pathToCachedDir', 'sops'),
-         '777'
-      )
+      expect(mockChmodSync).toHaveBeenCalledTimes(1)
    })
 
    test('downloadSops() - Windows uses .exe suffix in cached filename', async () => {
@@ -233,6 +255,7 @@ describe('run.ts', () => {
       mockArch.mockReturnValue('x64')
       mockChmodSync.mockImplementation(() => {})
       mockExistsSync.mockReturnValue(true)
+      mockAccessSync.mockImplementation(() => {})
 
       expect(await run.downloadSops(downloadBaseURL, 'v3.13.0')).toBe(
          path.join('pathToCachedDir', 'sops.exe')
@@ -272,12 +295,32 @@ describe('run.ts', () => {
       mockArch.mockReturnValue('x64')
       mockChmodSync.mockImplementation(() => {})
       mockExistsSync.mockReturnValue(true)
+      mockAccessSync.mockImplementation(() => {})
 
       expect(await run.downloadSops(downloadBaseURL, 'v3.13.0')).toBe(
          path.join('pathToCachedDir', 'sops')
       )
       expect(mockFind).toHaveBeenCalledWith('sops', 'v3.13.0')
       expect(mockDownloadTool).not.toHaveBeenCalled()
+      expect(mockChmodSync).not.toHaveBeenCalled()
+   })
+
+   test('downloadSops() - call chmod if cached file is not executable', async () => {
+      mockFind.mockReturnValue('pathToCachedDir')
+      mockDownloadTool.mockResolvedValue('pathToTool')
+      mockCacheFile.mockResolvedValue('pathToCachedDir')
+      mockPlatform.mockReturnValue('linux')
+      mockArch.mockReturnValue('x64')
+      mockChmodSync.mockImplementation(() => {})
+      mockExistsSync.mockReturnValue(true)
+      mockAccessSync.mockImplementation(() => {
+         throw new Error('Not executable')
+      })
+
+      expect(await run.downloadSops(downloadBaseURL, 'v3.13.0')).toBe(
+         path.join('pathToCachedDir', 'sops')
+      )
+      expect(mockFind).toHaveBeenCalledWith('sops', 'v3.13.0')
       expect(mockChmodSync).toHaveBeenCalledWith(
          path.join('pathToCachedDir', 'sops'),
          '777'

--- a/src/run.ts
+++ b/src/run.ts
@@ -102,6 +102,15 @@ export function getSopsDownloadURL(baseURL: string, version: string): string {
    return url.toString()
 }
 
+export function isExecutable(filePath: string): boolean {
+   try {
+      fs.accessSync(filePath, fs.constants.X_OK)
+      return true
+   } catch {
+      return false
+   }
+}
+
 export async function downloadSops(
    baseURL: string,
    version: string
@@ -142,6 +151,8 @@ export async function downloadSops(
       throw new Error(`SOPS executable not found in path ${cachedToolpath}`)
    }
 
-   fs.chmodSync(sopspath, '777')
+   if (!isExecutable(sopspath)) {
+      fs.chmodSync(sopspath, '777')
+   }
    return sopspath
 }


### PR DESCRIPTION
## Environment variables to add/change
N/A

## What does this pull request do?
Skips the final `fs.chmodSync` call if the selected binary is already executable to fix #250.

## How should this pull request be tested?
- Unit tests have been added in this PR
- Existing integration tests should confirm that this fix does not break existing behavior
- The issue that is fixed is not reproducible in this repo's CI: the actual bug only manifests when restoring from a RUNNER_TOOL_CACHE that does not support `chmod`. I have verified against my orgs self-hosted setup and am happy to share more details if useful. Reproducing a full setup to test seems out of scope for this repo

## Questions or comments:
N/A