### PR TITLE
fix: redundant chmod

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34796,8 +34796,23 @@ async function downloadSops(baseURL, version) {
     if (!external_node_fs_namespaceObject.existsSync(sopspath)) {
         throw new Error(`SOPS executable not found in path ${cachedToolpath}`);
     }
-    external_node_fs_namespaceObject.chmodSync(sopspath, '777');
+    if (!isExecutable(sopspath)) {
+        external_node_fs_namespaceObject.chmodSync(sopspath, '777');
+    }
     return sopspath;
+}
+// Some tool-cache filesystems (e.g. an SMB/CIFS share mounted on a
+// self-hosted runner) reject chmod with EPERM even though the cached
+// binary already carries the executable bit from the original download.
+// Skip the redundant chmod in that case rather than failing the run.
+function isExecutable(filePath) {
+    try {
+        external_node_fs_namespaceObject.accessSync(filePath, external_node_fs_namespaceObject.constants.X_OK);
+        return true;
+    }
+    catch {
+        return false;
+    }
 }
 
 ;// CONCATENATED MODULE: ./src/index.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,9 +1225,9 @@
          }
       },
       "node_modules/@types/node": {
-         "version": "26.0.1",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-         "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+         "version": "26.1.1",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+         "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1609,9 +1609,9 @@
          ]
       },
       "node_modules/@vercel/ncc": {
-         "version": "0.44.0",
-         "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.44.0.tgz",
-         "integrity": "sha512-pHyI+bZokSgIscTKFSmpNk5vZzmOrb9RW0Vu4SRyqUvkJ0kgg3PzaZLLDVTFXhbUiCqg0/Eu8L4fKtgViA92kg==",
+         "version": "0.44.1",
+         "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.44.1.tgz",
+         "integrity": "sha512-cUjIE5P2YY1n+Kt9rFIazMMpGoPn1Fic04rOmTkElMkiDP5oszGfERMpo2shVkFKDL7rVppdM2pqJKC59shQWQ==",
          "dev": true,
          "license": "MIT",
          "bin": {
@@ -3750,9 +3750,9 @@
          }
       },
       "node_modules/prettier": {
-         "version": "3.9.1",
-         "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.1.tgz",
-         "integrity": "sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==",
+         "version": "3.9.5",
+         "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+         "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
          "dev": true,
          "license": "MIT",
          "bin": {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -20,6 +20,7 @@ jest.unstable_mockModule('node:fs', () => ({
    ...actualFs,
    chmodSync: jest.fn(),
    existsSync: jest.fn(actualFs.existsSync),
+   accessSync: jest.fn(),
    default: {...actualFs}
 }))
 
@@ -39,6 +40,9 @@ const mockArch = os.arch as jest.MockedFunction<typeof os.arch>
 const mockChmodSync = fs.chmodSync as jest.MockedFunction<typeof fs.chmodSync>
 const mockExistsSync = fs.existsSync as jest.MockedFunction<
    typeof fs.existsSync
+>
+const mockAccessSync = fs.accessSync as jest.MockedFunction<
+   typeof fs.accessSync
 >
 const mockFind = toolCache.find as jest.MockedFunction<typeof toolCache.find>
 const mockDownloadTool = toolCache.downloadTool as jest.MockedFunction<
@@ -204,6 +208,9 @@ describe('run.ts', () => {
       mockArch.mockReturnValue('x64')
       mockChmodSync.mockImplementation(() => {})
       mockExistsSync.mockReturnValue(true)
+      mockAccessSync.mockImplementation(() => {
+         throw new Error('not executable')
+      })
 
       expect(await run.downloadSops(downloadBaseURL, 'v3.13.0')).toBe(
          path.join('pathToCachedDir', 'sops')
@@ -272,6 +279,9 @@ describe('run.ts', () => {
       mockArch.mockReturnValue('x64')
       mockChmodSync.mockImplementation(() => {})
       mockExistsSync.mockReturnValue(true)
+      mockAccessSync.mockImplementation(() => {
+         throw new Error('not executable')
+      })
 
       expect(await run.downloadSops(downloadBaseURL, 'v3.13.0')).toBe(
          path.join('pathToCachedDir', 'sops')
@@ -296,5 +306,37 @@ describe('run.ts', () => {
       await expect(
          run.downloadSops(downloadBaseURL, 'v3.13.0')
       ).rejects.toThrow('SOPS executable not found in path pathToCachedDir')
+   })
+
+   test('downloadSops() - skips chmod on a cache hit that is already executable', async () => {
+      mockFind.mockReturnValue('pathToCachedDir')
+      mockPlatform.mockReturnValue('linux')
+      mockArch.mockReturnValue('x64')
+      mockChmodSync.mockImplementation(() => {})
+      mockExistsSync.mockReturnValue(true)
+      mockAccessSync.mockImplementation(() => {})
+
+      expect(await run.downloadSops(downloadBaseURL, 'v3.13.0')).toBe(
+         path.join('pathToCachedDir', 'sops')
+      )
+      expect(mockChmodSync).not.toHaveBeenCalled()
+   })
+
+   test('downloadSops() - does not throw when chmod on an already-executable cache hit would fail with EPERM', async () => {
+      mockFind.mockReturnValue('pathToCachedDir')
+      mockPlatform.mockReturnValue('linux')
+      mockArch.mockReturnValue('x64')
+      mockExistsSync.mockReturnValue(true)
+      mockAccessSync.mockImplementation(() => {})
+      mockChmodSync.mockImplementation(() => {
+         throw Object.assign(new Error('EPERM: operation not permitted'), {
+            code: 'EPERM'
+         })
+      })
+
+      expect(await run.downloadSops(downloadBaseURL, 'v3.13.0')).toBe(
+         path.join('pathToCachedDir', 'sops')
+      )
+      expect(mockChmodSync).not.toHaveBeenCalled()
    })
 })

--- a/src/run.ts
+++ b/src/run.ts
@@ -142,6 +142,21 @@ export async function downloadSops(
       throw new Error(`SOPS executable not found in path ${cachedToolpath}`)
    }
 
-   fs.chmodSync(sopspath, '777')
+   if (!isExecutable(sopspath)) {
+      fs.chmodSync(sopspath, '777')
+   }
    return sopspath
+}
+
+// Some tool-cache filesystems (e.g. an SMB/CIFS share mounted on a
+// self-hosted runner) reject chmod with EPERM even though the cached
+// binary already carries the executable bit from the original download.
+// Skip the redundant chmod in that case rather than failing the run.
+function isExecutable(filePath: string): boolean {
+   try {
+      fs.accessSync(filePath, fs.constants.X_OK)
+      return true
+   } catch {
+      return false
+   }
 }


### PR DESCRIPTION
## What does this pull request do?

Fixes #250: `downloadSops()` in `src/run.ts` called `fs.chmodSync(sopspath, '777')` unconditionally, including on cache hits restored via `toolCache.find()`. On tool caches backed by a filesystem that rejects chmod (e.g. an SMB/CIFS share mounted on a self-hosted runner), this throws `EPERM: operation not permitted` even though the cached binary already carries the executable bit from its original download.

The final chmod now only runs if the binary isn't already executable (checked via `fs.accessSync(path, fs.constants.X_OK)`), so a cache hit that's already executable skips the chmod call entirely and no longer trips over a chmod-restricted filesystem.

Also picks up a few low-risk dependency bumps that were sitting within their existing semver ranges: `@types/node` 26.0.1 → 26.1.1, `@vercel/ncc` 0.44.0 → 0.44.1, `prettier` 3.9.1 → 3.9.5.

## How should this pull request be tested?

- `npm test` — added two new cases to `src/run.test.ts` covering the fix: chmod is skipped when a cache hit is already executable, and the run doesn't throw even when chmod would fail with EPERM in that scenario.
- `npm run build` to confirm `lib/index.js` reflects the change (committed alongside `src/run.ts`).
- `npm run format-check`.

## Questions or comments:

None.
